### PR TITLE
System team via console

### DIFF
--- a/src/Console/SetSystemTeamCommand.php
+++ b/src/Console/SetSystemTeamCommand.php
@@ -28,6 +28,6 @@ class SetSystemTeamCommand extends Command
      */
     public function handle()
     {
-        JetstreamTurbo::setSystemTeamAs($this->argument('team'))
+        JetstreamTurbo::setSystemTeamAs($this->argument('team'));
     }
 }

--- a/src/Console/SetSystemTeamCommand.php
+++ b/src/Console/SetSystemTeamCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LaravelTurbo\JetstreamTurbo\Console;
+
+use Illuminate\Console\Command;
+use LaravelTurbo\JetstreamTurbo;
+
+class SetSystemTeamCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'jetstream-turbo:set_system_team {team}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set team as a system team for Jetstream Turbo';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        JetstreamTurbo::setSystemTeamAs($this->argument('team'))
+    }
+}

--- a/src/JetstreamTurboServiceProvider.php
+++ b/src/JetstreamTurboServiceProvider.php
@@ -105,7 +105,7 @@ class JetstreamTurboServiceProvider extends ServiceProvider
 
         $this->commands([
             Console\InstallCommand::class,
-            Console\SetSystemTeamCommand::class
+            Console\SetSystemTeamCommand::class,
         ]);
     }
 

--- a/src/JetstreamTurboServiceProvider.php
+++ b/src/JetstreamTurboServiceProvider.php
@@ -105,6 +105,7 @@ class JetstreamTurboServiceProvider extends ServiceProvider
 
         $this->commands([
             Console\InstallCommand::class,
+            Console\SetSystemTeamCommand::class
         ]);
     }
 

--- a/stubs/app/Providers/JetstreamTurboServiceProvider.php
+++ b/stubs/app/Providers/JetstreamTurboServiceProvider.php
@@ -25,7 +25,6 @@ class JetstreamTurboServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //JetstreamTurbo::setSystemTeamAs(1);
         JetstreamTurbo::transferTeamsUsing(TransferTeam::class);
     }
 }


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes, this makes it easy to set a existing team to be a system team

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

No

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

This avoids the need to implement it in a provider

5️⃣ Thanks for contributing! 🙌
