### PR TITLE
Drop 7.4 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0]
+        php: [8.0]
         dependency-version: [prefer-stable]
         laravel: [^8.0]
 


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?

Yes to support upcoming features support for php 7.4 is being dropped

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)

N/A

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.

Upcoming features required php 8 

5️⃣ Thanks for contributing! 🙌
